### PR TITLE
load securityHandlers from sails api/swagger/securityHandlers.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,15 @@ module.exports = function swaggerHook(sails) {
         mockControllersDirs: [path.resolve(sails.config.paths.controllers, '..', 'mocks')],
         swaggerFile: path.resolve(sails.config.paths.controllers, '..', 'swagger', "swagger.yaml")
       };
-
+      try {
+        var secHandFile = path.resolve(sails.config.paths.controllers, '..', 'swagger', 'securityHandlers.js');
+        config.swaggerSecurityHandlers = require(secHandFile).securityHandlers;
+        sails.log.verbose("swaggerSecurityHandlers loaded successfully from securitySHandlers.js");
+      } catch(err) {
+        if ( err.code !== "MODULE_NOT_FOUND" ) {
+          return cb(err);
+        }
+      };
       SwaggerRunner.create(config, function(err, runner) {
         if (err) { return cb(err); }
 


### PR DESCRIPTION
```
Example of sails swagger security file: api/swagger/securityHandlers.js

  module.exports.securityHandlers = {
    mybasic:function securityHandler1(req, authOrSecDef, scopesOrApiKey, cb) {
        // your security code
        cb();
        },
  };

Extract of api/swagger/swagger.yaml
...
securityDefinitions:
  mybasic:
     type: basic
paths:
  /hello:
     # binds a127 app logic to a route
     x-swagger-router-controller: hello_world
     get:
       security:
         - mybasic: []
...
```
